### PR TITLE
Harden SQLite concurrency and outbox reliability

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -12,6 +12,7 @@ import {
   getDisplayId,
   resolveIssueId,
   isLocalId,
+  runWithBusyRetry,
 } from "../utils/database.js";
 import {
   createIssue,
@@ -342,7 +343,9 @@ export const createCommand = new Command("create")
 
           queueOutboxItem("create", payload, localId);
         });
-        transaction();
+        runWithBusyRetry(() => {
+          transaction();
+        });
 
         // Spawn background worker if not already running
         ensureOutboxProcessed();

--- a/src/commands/dep.ts
+++ b/src/commands/dep.ts
@@ -404,13 +404,13 @@ const listCommand = new Command("list")
   .option("-j, --json", "Output as JSON")
   .action(async (issueId: string, options) => {
     try {
-      const issue = getCachedIssue(issueId);
+      const resolvedId = resolveIssueId(issueId);
+      const issue = getCachedIssue(resolvedId);
       if (!issue) {
         outputError(`Issue not found: ${issueId}`);
         process.exit(1);
       }
 
-      const resolvedId = resolveIssueId(issueId);
       const { outgoing, incoming } = getAllDependencies(resolvedId);
 
       // Group dependencies by type
@@ -540,14 +540,15 @@ const treeCommand = new Command("tree")
   .argument("<issue>", "Issue ID")
   .action(async (issueId: string) => {
     try {
-      const issue = getCachedIssue(issueId);
+      const resolvedId = resolveIssueId(issueId);
+      const issue = getCachedIssue(resolvedId);
       if (!issue) {
         outputError(`Issue not found: ${issueId}`);
         process.exit(1);
       }
 
-      output(`\n🌲 Dependency tree for ${issueId}:\n`);
-      printTree(issueId);
+      output(`\n🌲 Dependency tree for ${getDisplayId(resolvedId)}:\n`);
+      printTree(resolvedId);
       output("");
     } catch (error) {
       outputError(error instanceof Error ? error.message : String(error));

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -166,7 +166,12 @@ export const updateCommand = new Command("update")
         process.exit(1);
       }
 
-      if (Object.keys(updates).length === 0 && allDeps.length === 0 && !options.parent && !options.unparent) {
+      if (
+        Object.keys(updates).length === 0 &&
+        allDeps.length === 0 &&
+        !options.parent &&
+        !options.unparent
+      ) {
         outputError("No updates specified");
         process.exit(1);
       }
@@ -197,9 +202,9 @@ export const updateCommand = new Command("update")
         // Handle unparent
         if (options.unparent) {
           const db = getDatabase();
-          const parentDep = db.query(
-            "SELECT * FROM dependencies WHERE issue_id = ? AND type = 'parent-child'"
-          ).get(resolvedId) as { depends_on_id: string } | null;
+          const parentDep = db
+            .query("SELECT * FROM dependencies WHERE issue_id = ? AND type = 'parent-child'")
+            .get(resolvedId) as { depends_on_id: string } | null;
           if (parentDep) {
             deleteDependency(resolvedId, parentDep.depends_on_id);
           }
@@ -272,9 +277,9 @@ export const updateCommand = new Command("update")
             await updateIssueParent(resolvedId, null);
             // Also remove from local cache
             const db = getDatabase();
-            const parentDep = db.query(
-              "SELECT * FROM dependencies WHERE issue_id = ? AND type = 'parent-child'"
-            ).get(resolvedId) as { depends_on_id: string } | null;
+            const parentDep = db
+              .query("SELECT * FROM dependencies WHERE issue_id = ? AND type = 'parent-child'")
+              .get(resolvedId) as { depends_on_id: string } | null;
             if (parentDep) {
               deleteDependency(resolvedId, parentDep.depends_on_id);
             }
@@ -373,9 +378,9 @@ export const updateCommand = new Command("update")
 
           if (options.unparent) {
             const db = getDatabase();
-            const parentDep = db.query(
-              "SELECT * FROM dependencies WHERE issue_id = ? AND type = 'parent-child'"
-            ).get(resolvedId) as { depends_on_id: string } | null;
+            const parentDep = db
+              .query("SELECT * FROM dependencies WHERE issue_id = ? AND type = 'parent-child'")
+              .get(resolvedId) as { depends_on_id: string } | null;
             if (parentDep) {
               deleteDependency(resolvedId, parentDep.depends_on_id);
             }

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -16,6 +16,8 @@ const SQLITE_BUSY_TIMEOUT_MS = 10000;
 const SQLITE_MAX_LOCK_RETRIES = 20;
 const SQLITE_RETRY_BASE_DELAY_MS = 50;
 const OUTBOX_CLAIM_TIMEOUT_MS = 60000;
+const OUTBOX_RETRY_BASE_DELAY_MS = 1000;
+const OUTBOX_RETRY_MAX_DELAY_MS = 300000;
 const LINEAR_ID_WITH_DASH_RE = /^([A-Za-z]+)-(\d+)$/;
 const LINEAR_ID_NO_DASH_RE = /^([A-Za-z]+)(\d+)$/;
 const NUMERIC_ISSUE_ID_RE = /^\d+$/;
@@ -228,6 +230,7 @@ function initSchema(db: Database): void {
       payload TEXT NOT NULL,
       local_id TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      next_attempt_at TEXT,
       processing INTEGER NOT NULL DEFAULT 0,
       processing_started_at TEXT,
       retry_count INTEGER NOT NULL DEFAULT 0,
@@ -276,6 +279,16 @@ function initSchema(db: Database): void {
     }
 
     db.exec("PRAGMA user_version = 3");
+  }
+
+  if (currentVersion < 4) {
+    const outboxCols = db.query("PRAGMA table_info(outbox)").all() as Array<{ name: string }>;
+
+    if (!outboxCols.some((c) => c.name === "next_attempt_at")) {
+      db.exec("ALTER TABLE outbox ADD COLUMN next_attempt_at TEXT");
+    }
+
+    db.exec("PRAGMA user_version = 4");
   }
 }
 
@@ -795,9 +808,16 @@ export function queueOutboxItem(
  */
 export function getPendingOutboxItems(): OutboxItem[] {
   const db = getDatabase();
-  const rows = db.query("SELECT * FROM outbox ORDER BY id ASC").all() as Array<
-    Record<string, unknown>
-  >;
+  const nowIso = new Date().toISOString();
+  const rows = db
+    .query(
+      `
+      SELECT * FROM outbox
+      WHERE next_attempt_at IS NULL OR next_attempt_at <= ?
+      ORDER BY id ASC
+    `
+    )
+    .all(nowIso) as Array<Record<string, unknown>>;
 
   return rows.map((row) => ({
     id: row.id as number,
@@ -849,7 +869,9 @@ export function claimOutboxItem(id: number): boolean {
     db.run(
       `
       UPDATE outbox
-      SET processing = 1, processing_started_at = ?
+      SET processing = 1,
+          processing_started_at = ?,
+          next_attempt_at = NULL
       WHERE id = ?
         AND (
           processing = 0
@@ -887,17 +909,40 @@ export function releaseOutboxItemClaim(id: number): void {
  */
 export function updateOutboxItemError(id: number, error: string): void {
   const db = getDatabase();
+  const row = runWithBusyRetry(
+    () => db.query("SELECT retry_count FROM outbox WHERE id = ?").get(id) as { retry_count: number } | null
+  );
+
+  if (!row) {
+    return;
+  }
+
+  const nextRetryCount = row.retry_count + 1;
+  const retryAfterSecondsMatch = error.match(/retry-?after"?\s*[:=]\s*"?(\d{1,6})/i);
+  const retryAfterSeconds = retryAfterSecondsMatch ? parseInt(retryAfterSecondsMatch[1], 10) : null;
+  const isRateLimited = error.toLowerCase().includes("rate limit");
+  const backoffMs = retryAfterSeconds
+    ? Math.min(retryAfterSeconds * 1000, OUTBOX_RETRY_MAX_DELAY_MS)
+    : isRateLimited
+      ? 60000
+      : Math.min(
+          OUTBOX_RETRY_BASE_DELAY_MS * 2 ** Math.min(nextRetryCount - 1, 8),
+          OUTBOX_RETRY_MAX_DELAY_MS
+        );
+  const nextAttemptAt = new Date(Date.now() + backoffMs).toISOString();
+
   runWithBusyRetry(() => {
     db.run(
       `
     UPDATE outbox 
-    SET retry_count = retry_count + 1,
+    SET retry_count = ?,
         last_error = ?,
+        next_attempt_at = ?,
         processing = 0,
         processing_started_at = NULL
     WHERE id = ?
   `,
-      [error, id]
+      [nextRetryCount, error, nextAttemptAt, id]
     );
   });
 }

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -259,19 +259,21 @@ function initSchema(db: Database): void {
 export function generateLocalId(): string {
   const db = getDatabase();
 
-  // Get current counter
-  const row = db.query("SELECT value FROM metadata WHERE key = 'local_id_counter'").get() as {
-    value: string;
-  } | null;
-
-  const nextNum = row ? parseInt(row.value) + 1 : 1;
-
-  // Update counter
-  runWithBusyRetry(() => {
-    db.run("INSERT OR REPLACE INTO metadata (key, value) VALUES ('local_id_counter', ?)", [
-      nextNum.toString(),
-    ]);
-  });
+  // Increment counter atomically to avoid duplicate LOCAL IDs under parallel writes.
+  const row = runWithBusyRetry(
+    () =>
+      db
+        .query(
+          `
+        INSERT INTO metadata (key, value)
+        VALUES ('local_id_counter', '1')
+        ON CONFLICT(key) DO UPDATE SET value = CAST(value AS INTEGER) + 1
+        RETURNING value
+      `
+        )
+        .get() as { value: string }
+  );
+  const nextNum = parseInt(row.value, 10);
 
   return `LOCAL-${nextNum.toString().padStart(3, "0")}`;
 }

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -811,6 +811,22 @@ export function getPendingOutboxItems(): OutboxItem[] {
 }
 
 /**
+ * Get current outbox queue stats, including number of claimed in-flight items.
+ */
+export function getOutboxStats(): { total: number; processing: number } {
+  const db = getDatabase();
+  const totalRow = db.query("SELECT COUNT(*) as count FROM outbox").get() as { count: number };
+  const processingRow = db
+    .query("SELECT COUNT(*) as count FROM outbox WHERE processing = 1")
+    .get() as { count: number };
+
+  return {
+    total: totalRow.count,
+    processing: processingRow.count,
+  };
+}
+
+/**
  * Remove item from outbox (after successful sync)
  */
 export function removeOutboxItem(id: number): void {

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -61,10 +61,16 @@ export function getDatabase(): Database {
     }
 
     db = new Database(dbPath);
-    db.exec("PRAGMA journal_mode = WAL");
-    db.exec("PRAGMA synchronous = NORMAL");
     db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
     runWithBusyRetry(() => {
+      const journalModeRow = db!
+        .query("PRAGMA journal_mode")
+        .get() as { journal_mode?: string } | null;
+      const journalMode = journalModeRow?.journal_mode?.toLowerCase();
+      if (journalMode !== "wal") {
+        db!.exec("PRAGMA journal_mode = WAL");
+      }
+      db!.exec("PRAGMA synchronous = NORMAL");
       initSchema(db!);
     });
   }
@@ -1068,12 +1074,6 @@ export function getCachedViewer(): { id: string; email: string; name: string } |
  */
 export function closeDatabase(): void {
   if (db) {
-    // Checkpoint WAL before closing to ensure all writes are in main DB
-    try {
-      db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
-    } catch {
-      // Ignore checkpoint errors on close
-    }
     db.close();
     db = null;
   }

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -69,9 +69,9 @@ export function getDatabase(): Database {
     db = new Database(dbPath);
     db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
     runWithBusyRetry(() => {
-      const journalModeRow = db!
-        .query("PRAGMA journal_mode")
-        .get() as { journal_mode?: string } | null;
+      const journalModeRow = db!.query("PRAGMA journal_mode").get() as {
+        journal_mode?: string;
+      } | null;
       const journalMode = journalModeRow?.journal_mode?.toLowerCase();
       if (journalMode !== "wal") {
         db!.exec("PRAGMA journal_mode = WAL");
@@ -910,7 +910,10 @@ export function releaseOutboxItemClaim(id: number): void {
 export function updateOutboxItemError(id: number, error: string): void {
   const db = getDatabase();
   const row = runWithBusyRetry(
-    () => db.query("SELECT retry_count FROM outbox WHERE id = ?").get(id) as { retry_count: number } | null
+    () =>
+      db.query("SELECT retry_count FROM outbox WHERE id = ?").get(id) as {
+        retry_count: number;
+      } | null
   );
 
   if (!row) {
@@ -1125,8 +1128,9 @@ function inferTeamPrefixForIssueNumber(issueNumber: string): string {
 
   const exactMatchPrefixes = runWithBusyRetry(
     () =>
-      db.query(
-        `
+      db
+        .query(
+          `
         SELECT DISTINCT UPPER(substr(id, 1, instr(id, '-') - 1)) AS prefix
         FROM issues
         WHERE instr(id, '-') > 1
@@ -1137,13 +1141,15 @@ function inferTeamPrefixForIssueNumber(issueNumber: string): string {
         WHERE instr(linear_id, '-') > 1
           AND CAST(substr(linear_id, instr(linear_id, '-') + 1) AS INTEGER) = ?
       `
-      ).all(suffixNumber, suffixNumber) as Array<{ prefix: string }>
+        )
+        .all(suffixNumber, suffixNumber) as Array<{ prefix: string }>
   );
 
   const cachedPrefixes = runWithBusyRetry(
     () =>
-      db.query(
-        `
+      db
+        .query(
+          `
         SELECT DISTINCT UPPER(substr(id, 1, instr(id, '-') - 1)) AS prefix
         FROM issues
         WHERE instr(id, '-') > 1
@@ -1152,7 +1158,8 @@ function inferTeamPrefixForIssueNumber(issueNumber: string): string {
         FROM issue_id_map
         WHERE instr(linear_id, '-') > 1
       `
-      ).all() as Array<{ prefix: string }>
+        )
+        .all() as Array<{ prefix: string }>
   );
 
   const candidates = new Set<string>();
@@ -1268,7 +1275,10 @@ export function replaceIssueId(localId: string, linearId: string): void {
     }
 
     db.run("UPDATE dependencies SET issue_id = ? WHERE issue_id = ?", [linearId, localId]);
-    db.run("UPDATE dependencies SET depends_on_id = ? WHERE depends_on_id = ?", [linearId, localId]);
+    db.run("UPDATE dependencies SET depends_on_id = ? WHERE depends_on_id = ?", [
+      linearId,
+      localId,
+    ]);
   });
 
   requestJsonlExport();

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -6,7 +6,7 @@
 import { Database } from "bun:sqlite";
 import { existsSync, mkdirSync } from "fs";
 import { dirname } from "path";
-import { getDbPath } from "./config.js";
+import { getDbPath, getTeamKey } from "./config.js";
 import { requestJsonlExport } from "./jsonl-scheduler.js";
 import type { Issue, Dependency, OutboxItem } from "../types.js";
 
@@ -15,6 +15,9 @@ const LOCAL_ID_PREFIX = "LOCAL-";
 const SQLITE_BUSY_TIMEOUT_MS = 10000;
 const SQLITE_MAX_LOCK_RETRIES = 20;
 const SQLITE_RETRY_BASE_DELAY_MS = 50;
+const LINEAR_ID_WITH_DASH_RE = /^([A-Za-z]+)-(\d+)$/;
+const LINEAR_ID_NO_DASH_RE = /^([A-Za-z]+)(\d+)$/;
+const NUMERIC_ISSUE_ID_RE = /^\d+$/;
 
 function isDatabaseLockedError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
@@ -983,12 +986,115 @@ export function isLocalId(id: string): boolean {
   return id.startsWith(LOCAL_ID_PREFIX);
 }
 
+function normalizeIssueNumber(raw: string): string {
+  const noLeadingZeros = raw.replace(/^0+(?=\d)/, "");
+  return noLeadingZeros.length > 0 ? noLeadingZeros : "0";
+}
+
+function inferTeamPrefixForIssueNumber(issueNumber: string): string {
+  const configuredTeamKey = getTeamKey()?.trim().toUpperCase();
+  const db = getDatabase();
+  const suffixNumber = parseInt(issueNumber, 10);
+
+  const exactMatchPrefixes = runWithBusyRetry(
+    () =>
+      db.query(
+        `
+        SELECT DISTINCT UPPER(substr(id, 1, instr(id, '-') - 1)) AS prefix
+        FROM issues
+        WHERE instr(id, '-') > 1
+          AND CAST(substr(id, instr(id, '-') + 1) AS INTEGER) = ?
+        UNION
+        SELECT DISTINCT UPPER(substr(linear_id, 1, instr(linear_id, '-') - 1)) AS prefix
+        FROM issue_id_map
+        WHERE instr(linear_id, '-') > 1
+          AND CAST(substr(linear_id, instr(linear_id, '-') + 1) AS INTEGER) = ?
+      `
+      ).all(suffixNumber, suffixNumber) as Array<{ prefix: string }>
+  );
+
+  const cachedPrefixes = runWithBusyRetry(
+    () =>
+      db.query(
+        `
+        SELECT DISTINCT UPPER(substr(id, 1, instr(id, '-') - 1)) AS prefix
+        FROM issues
+        WHERE instr(id, '-') > 1
+        UNION
+        SELECT DISTINCT UPPER(substr(linear_id, 1, instr(linear_id, '-') - 1)) AS prefix
+        FROM issue_id_map
+        WHERE instr(linear_id, '-') > 1
+      `
+      ).all() as Array<{ prefix: string }>
+  );
+
+  const candidates = new Set<string>();
+  if (configuredTeamKey) {
+    candidates.add(configuredTeamKey);
+  }
+  for (const row of exactMatchPrefixes) {
+    if (row.prefix) {
+      candidates.add(row.prefix);
+    }
+  }
+
+  if (!configuredTeamKey && candidates.size === 0) {
+    for (const row of cachedPrefixes) {
+      if (row.prefix) {
+        candidates.add(row.prefix);
+      }
+    }
+  }
+
+  if (candidates.size === 1) {
+    return [...candidates][0];
+  }
+
+  const choices = [...candidates].sort();
+  if (choices.length > 1) {
+    throw new Error(
+      `Issue reference '${issueNumber}' is ambiguous. Use one of: ${choices.map((p) => `${p}-${normalizeIssueNumber(issueNumber)}`).join(", ")}`
+    );
+  }
+
+  throw new Error(
+    `Cannot infer team prefix for '${issueNumber}'. Set LB_TEAM_KEY or provide a full issue ID like TEAM-${normalizeIssueNumber(issueNumber)}.`
+  );
+}
+
+function normalizeIssueInputId(id: string): string {
+  const trimmed = id.trim();
+  if (!trimmed) return trimmed;
+
+  if (isLocalId(trimmed)) {
+    return trimmed;
+  }
+
+  const dashedMatch = trimmed.match(LINEAR_ID_WITH_DASH_RE);
+  if (dashedMatch) {
+    return `${dashedMatch[1].toUpperCase()}-${normalizeIssueNumber(dashedMatch[2])}`;
+  }
+
+  const compactMatch = trimmed.match(LINEAR_ID_NO_DASH_RE);
+  if (compactMatch) {
+    return `${compactMatch[1].toUpperCase()}-${normalizeIssueNumber(compactMatch[2])}`;
+  }
+
+  if (NUMERIC_ISSUE_ID_RE.test(trimmed)) {
+    const prefix = inferTeamPrefixForIssueNumber(trimmed);
+    return `${prefix}-${normalizeIssueNumber(trimmed)}`;
+  }
+
+  return trimmed;
+}
+
 /**
  * Resolve input ID to Linear ID if mapping exists
  */
 export function resolveIssueId(id: string): string {
-  if (!isLocalId(id)) return id;
-  return getIssueIdMapping(id) || id;
+  const normalizedId = normalizeIssueInputId(id);
+  if (!isLocalId(normalizedId)) return normalizedId;
+  return getIssueIdMapping(normalizedId) || normalizedId;
 }
 
 /**

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -15,6 +15,7 @@ const LOCAL_ID_PREFIX = "LOCAL-";
 const SQLITE_BUSY_TIMEOUT_MS = 10000;
 const SQLITE_MAX_LOCK_RETRIES = 20;
 const SQLITE_RETRY_BASE_DELAY_MS = 50;
+const OUTBOX_CLAIM_TIMEOUT_MS = 60000;
 const LINEAR_ID_WITH_DASH_RE = /^([A-Za-z]+)-(\d+)$/;
 const LINEAR_ID_NO_DASH_RE = /^([A-Za-z]+)(\d+)$/;
 const NUMERIC_ISSUE_ID_RE = /^\d+$/;
@@ -227,6 +228,8 @@ function initSchema(db: Database): void {
       payload TEXT NOT NULL,
       local_id TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      processing INTEGER NOT NULL DEFAULT 0,
+      processing_started_at TEXT,
       retry_count INTEGER NOT NULL DEFAULT 0,
       last_error TEXT
     );
@@ -259,6 +262,20 @@ function initSchema(db: Database): void {
     `);
 
     db.exec("PRAGMA user_version = 2");
+  }
+
+  if (currentVersion < 3) {
+    const outboxCols = db.query("PRAGMA table_info(outbox)").all() as Array<{ name: string }>;
+
+    if (!outboxCols.some((c) => c.name === "processing")) {
+      db.exec("ALTER TABLE outbox ADD COLUMN processing INTEGER NOT NULL DEFAULT 0");
+    }
+
+    if (!outboxCols.some((c) => c.name === "processing_started_at")) {
+      db.exec("ALTER TABLE outbox ADD COLUMN processing_started_at TEXT");
+    }
+
+    db.exec("PRAGMA user_version = 3");
   }
 }
 
@@ -804,6 +821,52 @@ export function removeOutboxItem(id: number): void {
 }
 
 /**
+ * Attempt to claim an outbox item for processing.
+ * Returns true if claimed, false if another worker already holds the claim.
+ */
+export function claimOutboxItem(id: number): boolean {
+  const db = getDatabase();
+  const nowIso = new Date().toISOString();
+  const staleBeforeIso = new Date(Date.now() - OUTBOX_CLAIM_TIMEOUT_MS).toISOString();
+
+  return runWithBusyRetry(() => {
+    db.run(
+      `
+      UPDATE outbox
+      SET processing = 1, processing_started_at = ?
+      WHERE id = ?
+        AND (
+          processing = 0
+          OR processing_started_at IS NULL
+          OR processing_started_at < ?
+        )
+    `,
+      [nowIso, id, staleBeforeIso]
+    );
+
+    const result = db.query("SELECT changes() as count").get() as { count: number };
+    return result.count > 0;
+  });
+}
+
+/**
+ * Release processing claim without recording an error.
+ */
+export function releaseOutboxItemClaim(id: number): void {
+  const db = getDatabase();
+  runWithBusyRetry(() => {
+    db.run(
+      `
+      UPDATE outbox
+      SET processing = 0, processing_started_at = NULL
+      WHERE id = ?
+    `,
+      [id]
+    );
+  });
+}
+
+/**
  * Update outbox item with error
  */
 export function updateOutboxItemError(id: number, error: string): void {
@@ -812,7 +875,10 @@ export function updateOutboxItemError(id: number, error: string): void {
     db.run(
       `
     UPDATE outbox 
-    SET retry_count = retry_count + 1, last_error = ?
+    SET retry_count = retry_count + 1,
+        last_error = ?,
+        processing = 0,
+        processing_started_at = NULL
     WHERE id = ?
   `,
       [error, id]

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -12,6 +12,40 @@ import type { Issue, Dependency, OutboxItem } from "../types.js";
 
 let db: Database | null = null;
 const LOCAL_ID_PREFIX = "LOCAL-";
+const SQLITE_BUSY_TIMEOUT_MS = 10000;
+const SQLITE_MAX_LOCK_RETRIES = 20;
+const SQLITE_RETRY_BASE_DELAY_MS = 50;
+
+function isDatabaseLockedError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const msg = error.message.toLowerCase();
+  return (
+    msg.includes("database is locked") ||
+    msg.includes("database table is locked") ||
+    msg.includes("database schema is locked")
+  );
+}
+
+function sleepSync(ms: number): void {
+  const signal = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(signal, 0, 0, ms);
+}
+
+export function runWithBusyRetry<T>(operation: () => T): T {
+  let attempt = 0;
+  while (true) {
+    try {
+      return operation();
+    } catch (error) {
+      if (!isDatabaseLockedError(error) || attempt >= SQLITE_MAX_LOCK_RETRIES) {
+        throw error;
+      }
+      const backoffMs = SQLITE_RETRY_BASE_DELAY_MS * (attempt + 1);
+      sleepSync(backoffMs);
+      attempt++;
+    }
+  }
+}
 
 /**
  * Get database singleton, initializing schema if needed
@@ -29,7 +63,10 @@ export function getDatabase(): Database {
     db = new Database(dbPath);
     db.exec("PRAGMA journal_mode = WAL");
     db.exec("PRAGMA synchronous = NORMAL");
-    initSchema(db);
+    db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
+    runWithBusyRetry(() => {
+      initSchema(db!);
+    });
   }
   return db;
 }
@@ -230,9 +267,11 @@ export function generateLocalId(): string {
   const nextNum = row ? parseInt(row.value) + 1 : 1;
 
   // Update counter
-  db.run("INSERT OR REPLACE INTO metadata (key, value) VALUES ('local_id_counter', ?)", [
-    nextNum.toString(),
-  ]);
+  runWithBusyRetry(() => {
+    db.run("INSERT OR REPLACE INTO metadata (key, value) VALUES ('local_id_counter', ?)", [
+      nextNum.toString(),
+    ]);
+  });
 
   return `LOCAL-${nextNum.toString().padStart(3, "0")}`;
 }
@@ -281,9 +320,11 @@ export function getCacheInfo(): { lastSync: Date | null; ageSeconds: number; isS
 export function updateLastSync(): void {
   const db = getDatabase();
   // Store as ISO string with Z suffix so parsing knows it's UTC
-  db.run("INSERT OR REPLACE INTO metadata (key, value) VALUES ('last_sync', ?)", [
-    new Date().toISOString(),
-  ]);
+  runWithBusyRetry(() => {
+    db.run("INSERT OR REPLACE INTO metadata (key, value) VALUES ('last_sync', ?)", [
+      new Date().toISOString(),
+    ]);
+  });
   requestJsonlExport();
 }
 
@@ -331,9 +372,11 @@ export function incrementSyncRunCount(): number {
   const db = getDatabase();
   const current = getSyncRunCount();
   const next = current + 1;
-  db.run("INSERT OR REPLACE INTO metadata (key, value) VALUES ('sync_run_count', ?)", [
-    next.toString(),
-  ]);
+  runWithBusyRetry(() => {
+    db.run("INSERT OR REPLACE INTO metadata (key, value) VALUES ('sync_run_count', ?)", [
+      next.toString(),
+    ]);
+  });
   return next;
 }
 
@@ -353,9 +396,11 @@ export function getLastFullSync(): string | null {
  */
 export function updateLastFullSync(): void {
   const db = getDatabase();
-  db.run("INSERT OR REPLACE INTO metadata (key, value) VALUES ('last_full_sync', ?)", [
-    new Date().toISOString(),
-  ]);
+  runWithBusyRetry(() => {
+    db.run("INSERT OR REPLACE INTO metadata (key, value) VALUES ('last_full_sync', ?)", [
+      new Date().toISOString(),
+    ]);
+  });
 }
 
 /**
@@ -390,28 +435,30 @@ export function cacheIssue(
   issue: Issue & { linear_state_id?: string; sync_status?: "synced" | "pending" | "failed" }
 ): void {
   const db = getDatabase();
-  db.run(
-    `
+  runWithBusyRetry(() => {
+    db.run(
+      `
     INSERT OR REPLACE INTO issues 
     (id, identifier, title, description, status, priority, issue_type, sync_status, created_at, updated_at, closed_at, assignee, linear_state_id, cached_at)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
   `,
-    [
-      issue.id,
-      issue.id, // identifier same as id for now
-      issue.title,
-      issue.description || null,
-      issue.status,
-      issue.priority,
-      issue.issue_type || null,
-      issue.sync_status || "synced",
-      issue.created_at,
-      issue.updated_at,
-      issue.closed_at || null,
-      issue.assignee || null,
-      issue.linear_state_id || null,
-    ]
-  );
+      [
+        issue.id,
+        issue.id, // identifier same as id for now
+        issue.title,
+        issue.description || null,
+        issue.status,
+        issue.priority,
+        issue.issue_type || null,
+        issue.sync_status || "synced",
+        issue.created_at,
+        issue.updated_at,
+        issue.closed_at || null,
+        issue.assignee || null,
+        issue.linear_state_id || null,
+      ]
+    );
+  });
   requestJsonlExport();
 }
 
@@ -446,7 +493,9 @@ export function cacheIssues(issues: Array<Issue & { linear_state_id?: string }>)
     }
   });
 
-  transaction();
+  runWithBusyRetry(() => {
+    transaction();
+  });
   requestJsonlExport();
 }
 
@@ -518,14 +567,16 @@ export function getCachedIssues(): Issue[] {
  */
 export function cacheDependency(dep: Dependency): void {
   const db = getDatabase();
-  db.run(
-    `
+  runWithBusyRetry(() => {
+    db.run(
+      `
     INSERT OR REPLACE INTO dependencies 
     (issue_id, depends_on_id, type, created_at, created_by)
     VALUES (?, ?, ?, ?, ?)
   `,
-    [dep.issue_id, dep.depends_on_id, dep.type, dep.created_at, dep.created_by]
-  );
+      [dep.issue_id, dep.depends_on_id, dep.type, dep.created_at, dep.created_by]
+    );
+  });
   requestJsonlExport();
 }
 
@@ -535,7 +586,9 @@ export function cacheDependency(dep: Dependency): void {
 export function clearIssueDependencies(issueId: string): void {
   const db = getDatabase();
   const resolvedId = resolveIssueId(issueId);
-  db.run("DELETE FROM dependencies WHERE issue_id = ?", [resolvedId]);
+  runWithBusyRetry(() => {
+    db.run("DELETE FROM dependencies WHERE issue_id = ?", [resolvedId]);
+  });
   requestJsonlExport();
 }
 
@@ -546,15 +599,17 @@ export function deleteDependency(issueId: string, dependsOnId: string): void {
   const db = getDatabase();
   const resolvedIssueId = resolveIssueId(issueId);
   const resolvedDependsOnId = resolveIssueId(dependsOnId);
-  db.run("DELETE FROM dependencies WHERE issue_id = ? AND depends_on_id = ?", [
-    resolvedIssueId,
-    resolvedDependsOnId,
-  ]);
-  // Also try the reverse direction
-  db.run("DELETE FROM dependencies WHERE issue_id = ? AND depends_on_id = ?", [
-    resolvedDependsOnId,
-    resolvedIssueId,
-  ]);
+  runWithBusyRetry(() => {
+    db.run("DELETE FROM dependencies WHERE issue_id = ? AND depends_on_id = ?", [
+      resolvedIssueId,
+      resolvedDependsOnId,
+    ]);
+    // Also try the reverse direction
+    db.run("DELETE FROM dependencies WHERE issue_id = ? AND depends_on_id = ?", [
+      resolvedDependsOnId,
+      resolvedIssueId,
+    ]);
+  });
   requestJsonlExport();
 }
 
@@ -692,13 +747,15 @@ export function queueOutboxItem(
   localId?: string
 ): number {
   const db = getDatabase();
-  db.run(
-    `
+  runWithBusyRetry(() => {
+    db.run(
+      `
     INSERT INTO outbox (operation, payload, local_id)
     VALUES (?, ?, ?)
   `,
-    [operation, JSON.stringify(payload), localId || null]
-  );
+      [operation, JSON.stringify(payload), localId || null]
+    );
+  });
 
   // Get last insert rowid
   const result = db.query("SELECT last_insert_rowid() as id").get() as { id: number };
@@ -730,7 +787,9 @@ export function getPendingOutboxItems(): OutboxItem[] {
  */
 export function removeOutboxItem(id: number): void {
   const db = getDatabase();
-  db.run("DELETE FROM outbox WHERE id = ?", [id]);
+  runWithBusyRetry(() => {
+    db.run("DELETE FROM outbox WHERE id = ?", [id]);
+  });
 }
 
 /**
@@ -738,14 +797,16 @@ export function removeOutboxItem(id: number): void {
  */
 export function updateOutboxItemError(id: number, error: string): void {
   const db = getDatabase();
-  db.run(
-    `
+  runWithBusyRetry(() => {
+    db.run(
+      `
     UPDATE outbox 
     SET retry_count = retry_count + 1, last_error = ?
     WHERE id = ?
   `,
-    [error, id]
-  );
+      [error, id]
+    );
+  });
 }
 
 /**
@@ -754,13 +815,15 @@ export function updateOutboxItemError(id: number, error: string): void {
  */
 export function clearCache(): void {
   const db = getDatabase();
-  db.exec(`
+  runWithBusyRetry(() => {
+    db.exec(`
     DELETE FROM issues;
     DELETE FROM dependencies WHERE type = 'parent-child';
     DELETE FROM labels;
     DELETE FROM projects;
     DELETE FROM metadata;
   `);
+  });
   requestJsonlExport();
 }
 
@@ -769,10 +832,12 @@ export function clearCache(): void {
  */
 export function clearIssuesCache(): void {
   const db = getDatabase();
-  db.exec(`
+  runWithBusyRetry(() => {
+    db.exec(`
     DELETE FROM issues;
     DELETE FROM dependencies WHERE type = 'parent-child';
   `);
+  });
   requestJsonlExport();
 }
 
@@ -782,11 +847,13 @@ export function clearIssuesCache(): void {
 export function deleteCachedIssue(issueId: string): void {
   const db = getDatabase();
   const resolvedId = resolveIssueId(issueId);
-  db.run("DELETE FROM issues WHERE id = ?", [resolvedId]);
-  db.run("DELETE FROM dependencies WHERE issue_id = ? OR depends_on_id = ?", [
-    resolvedId,
-    resolvedId,
-  ]);
+  runWithBusyRetry(() => {
+    db.run("DELETE FROM issues WHERE id = ?", [resolvedId]);
+    db.run("DELETE FROM dependencies WHERE issue_id = ? OR depends_on_id = ?", [
+      resolvedId,
+      resolvedId,
+    ]);
+  });
   requestJsonlExport();
 }
 
@@ -795,13 +862,15 @@ export function deleteCachedIssue(issueId: string): void {
  */
 export function cacheLabel(id: string, name: string, teamId?: string): void {
   const db = getDatabase();
-  db.run(
-    `
+  runWithBusyRetry(() => {
+    db.run(
+      `
     INSERT OR REPLACE INTO labels (id, name, team_id)
     VALUES (?, ?, ?)
   `,
-    [id, name, teamId || null]
-  );
+      [id, name, teamId || null]
+    );
+  });
 }
 
 /**
@@ -818,13 +887,15 @@ export function getLabelIdByName(name: string): string | null {
  */
 export function cacheProject(id: string, name: string, teamId?: string): void {
   const db = getDatabase();
-  db.run(
-    `
+  runWithBusyRetry(() => {
+    db.run(
+      `
     INSERT OR REPLACE INTO projects (id, name, team_id)
     VALUES (?, ?, ?)
   `,
-    [id, name, teamId || null]
-  );
+      [id, name, teamId || null]
+    );
+  });
 }
 
 /**
@@ -856,13 +927,15 @@ export function pruneStaleIssues(validIds: Set<string>): number {
   const allIds = getAllCachedIssueIds();
   let pruned = 0;
 
-  for (const id of allIds) {
-    if (!validIds.has(id)) {
-      db.run("DELETE FROM issues WHERE id = ?", [id]);
-      db.run("DELETE FROM dependencies WHERE issue_id = ? OR depends_on_id = ?", [id, id]);
-      pruned++;
+  runWithBusyRetry(() => {
+    for (const id of allIds) {
+      if (!validIds.has(id)) {
+        db.run("DELETE FROM issues WHERE id = ?", [id]);
+        db.run("DELETE FROM dependencies WHERE issue_id = ? OR depends_on_id = ?", [id, id]);
+        pruned++;
+      }
     }
-  }
+  });
 
   if (pruned > 0) {
     requestJsonlExport();
@@ -876,13 +949,15 @@ export function pruneStaleIssues(validIds: Set<string>): number {
  */
 export function setIssueIdMapping(localId: string, linearId: string): void {
   const db = getDatabase();
-  db.run(
-    `
+  runWithBusyRetry(() => {
+    db.run(
+      `
     INSERT OR REPLACE INTO issue_id_map (local_id, linear_id, created_at)
     VALUES (?, ?, ?)
   `,
-    [localId, linearId, new Date().toISOString()]
-  );
+      [localId, linearId, new Date().toISOString()]
+    );
+  });
 }
 
 /**
@@ -937,21 +1012,23 @@ export function replaceIssueId(localId: string, linearId: string): void {
     id: string;
   } | null;
 
-  if (existing) {
-    db.run("DELETE FROM issues WHERE id = ?", [localId]);
-  } else {
-    db.run(
-      `
+  runWithBusyRetry(() => {
+    if (existing) {
+      db.run("DELETE FROM issues WHERE id = ?", [localId]);
+    } else {
+      db.run(
+        `
       UPDATE issues
       SET id = ?, identifier = ?, sync_status = 'synced'
       WHERE id = ?
     `,
-      [linearId, linearId, localId]
-    );
-  }
+        [linearId, linearId, localId]
+      );
+    }
 
-  db.run("UPDATE dependencies SET issue_id = ? WHERE issue_id = ?", [linearId, localId]);
-  db.run("UPDATE dependencies SET depends_on_id = ? WHERE depends_on_id = ?", [linearId, localId]);
+    db.run("UPDATE dependencies SET issue_id = ? WHERE issue_id = ?", [linearId, localId]);
+    db.run("UPDATE dependencies SET depends_on_id = ? WHERE depends_on_id = ?", [linearId, localId]);
+  });
 
   requestJsonlExport();
 }
@@ -961,9 +1038,11 @@ export function replaceIssueId(localId: string, linearId: string): void {
  */
 export function cacheViewer(viewer: { id: string; email: string; name: string }): void {
   const db = getDatabase();
-  db.run("INSERT OR REPLACE INTO metadata (key, value) VALUES ('viewer', ?)", [
-    JSON.stringify(viewer),
-  ]);
+  runWithBusyRetry(() => {
+    db.run("INSERT OR REPLACE INTO metadata (key, value) VALUES ('viewer', ?)", [
+      JSON.stringify(viewer),
+    ]);
+  });
 }
 
 /**

--- a/src/utils/outbox-processor.ts
+++ b/src/utils/outbox-processor.ts
@@ -6,6 +6,8 @@ import type { Issue, IssueType, OutboxItem, Priority } from "../types.js";
 import {
   getPendingOutboxItems,
   removeOutboxItem,
+  claimOutboxItem,
+  releaseOutboxItemClaim,
   updateOutboxItemError,
   getIssueIdMapping,
   setIssueIdMapping,
@@ -358,11 +360,18 @@ export async function processOutboxQueue(
       continue;
     }
 
-    if (!resolution.canProcess || !resolution.resolvedPayload) {
-      if (resolution.primaryId) {
-        addBlockedId(resolution.primaryId);
+    if (!claimOutboxItem(item.id)) {
+      deferred++;
+      continue;
+    }
+
+    const claimedResolution = resolveOutboxItem(item);
+    if (!claimedResolution.canProcess || !claimedResolution.resolvedPayload) {
+      releaseOutboxItemClaim(item.id);
+      if (claimedResolution.primaryId) {
+        addBlockedId(claimedResolution.primaryId);
       }
-      for (const id of resolution.referencedIds) {
+      for (const id of claimedResolution.referencedIds) {
         addBlockedId(id);
       }
       deferred++;
@@ -370,7 +379,7 @@ export async function processOutboxQueue(
     }
 
     try {
-      await processResolvedItem(item, resolution.resolvedPayload, teamId, propagateParent);
+      await processResolvedItem(item, claimedResolution.resolvedPayload, teamId, propagateParent);
       removeOutboxItem(item.id);
       success++;
     } catch (error) {

--- a/src/utils/spawn-worker.ts
+++ b/src/utils/spawn-worker.ts
@@ -3,12 +3,14 @@
  */
 
 import { spawn } from "child_process";
-import { openSync, closeSync } from "fs";
+import { openSync, closeSync, statSync, unlinkSync } from "fs";
 import { join, dirname } from "path";
 import { isWorkerRunning, touchPidFile } from "./pid-manager.js";
 import { getDbPath } from "./config.js";
 import { queueOutboxItem } from "./database.js";
 import type { OutboxItem } from "../types.js";
+
+const SPAWN_LOCK_TTL_MS = 5000;
 
 /**
  * Get the command and args to run the worker
@@ -30,12 +32,52 @@ function getLogFilePath(): string {
   return join(dirname(getDbPath()), "sync.log");
 }
 
+function getSpawnLockPath(): string {
+  return join(dirname(getDbPath()), "sync.spawn.lock");
+}
+
+function withSpawnLock<T>(operation: () => T): T | null {
+  const lockPath = getSpawnLockPath();
+
+  try {
+    const stat = statSync(lockPath);
+    if (Date.now() - stat.mtimeMs > SPAWN_LOCK_TTL_MS) {
+      unlinkSync(lockPath);
+    }
+  } catch {
+    // No lock file
+  }
+
+  let lockFd: number;
+  try {
+    lockFd = openSync(lockPath, "wx");
+  } catch {
+    // Another process is spawning the worker right now.
+    return null;
+  }
+
+  try {
+    return operation();
+  } finally {
+    closeSync(lockFd);
+    try {
+      unlinkSync(lockPath);
+    } catch {
+      // If lock was already removed, ignore.
+    }
+  }
+}
+
 /**
  * Spawn background sync worker if needed
  * Returns true if spawned, false if already running
  */
 function spawnWorker(): boolean {
-  try {
+  const spawned = withSpawnLock(() => {
+    if (isWorkerRunning()) {
+      return false;
+    }
+
     const { cmd, args } = getWorkerCommand();
 
     // Log to file for debugging spawn failures
@@ -51,10 +93,13 @@ function spawnWorker(): boolean {
     closeSync(logFd);
 
     return true;
-  } catch (error) {
-    console.error("Warning: Failed to spawn background sync worker:", error);
+  });
+
+  if (spawned === null) {
     return false;
   }
+
+  return spawned;
 }
 
 /**

--- a/src/utils/sync.ts
+++ b/src/utils/sync.ts
@@ -9,6 +9,7 @@ import {
   incrementSyncRunCount,
   needsFullSync,
   getLastSync,
+  getOutboxStats,
 } from "./database.js";
 import {
   fetchIssues,
@@ -24,9 +25,45 @@ import { processOutboxQueue } from "./outbox-processor.js";
 /**
  * Process outbox queue - push pending mutations to Linear
  */
+const OUTBOX_INFLIGHT_WAIT_MS = 1200;
+const OUTBOX_INFLIGHT_POLL_MS = 100;
+
 export async function pushOutbox(teamId: string): Promise<{ success: number; failed: number }> {
-  const result = await processOutboxQueue(teamId);
-  return { success: result.success, failed: result.failed };
+  let success = 0;
+  let failed = 0;
+  let waitedMs = 0;
+
+  while (true) {
+    const result = await processOutboxQueue(teamId);
+    success += result.success;
+    failed += result.failed;
+
+    if (result.deferred === 0) {
+      break;
+    }
+
+    if (result.success > 0 || result.failed > 0) {
+      continue;
+    }
+
+    const stats = getOutboxStats();
+    if (stats.total === 0 || stats.processing === 0) {
+      break;
+    }
+
+    if (waitedMs >= OUTBOX_INFLIGHT_WAIT_MS) {
+      break;
+    }
+
+    await sleep(OUTBOX_INFLIGHT_POLL_MS);
+    waitedMs += OUTBOX_INFLIGHT_POLL_MS;
+  }
+
+  return { success, failed };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -176,11 +176,13 @@ describe("lb CLI Integration Tests", () => {
         Array<{
           id: string;
           title: string;
+          sync_status: string;
         }>
       >("create", title, "-p", "1");
 
-      expect(result[0].id).toBe("pending");
+      expect(result[0].id).toMatch(/^LOCAL-\d+$/);
       expect(result[0].title).toBe(title);
+      expect(result[0].sync_status).toBe("pending");
 
       // Push it immediately so we can track it
       await lb("sync");
@@ -455,11 +457,15 @@ describe("lb CLI Integration Tests", () => {
     test("should queue and auto-sync in background", async () => {
       // Create without --sync flag (queues and spawns worker)
       const title = `${TEST_PREFIX} Background sync test`;
-      const createResult = await lbJson<Array<{ id: string; title: string }>>("create", title);
+      const createResult = await lbJson<Array<{ id: string; title: string; sync_status: string }>>(
+        "create",
+        title
+      );
 
-      // Should return immediately with pending ID
-      expect(createResult[0].id).toBe("pending");
+      // Should return immediately with local ID and pending sync status
+      expect(createResult[0].id).toMatch(/^LOCAL-\d+$/);
       expect(createResult[0].title).toBe(title);
+      expect(createResult[0].sync_status).toBe("pending");
 
       // Wait for worker to process queue (give it a few seconds)
       await new Promise((resolve) => setTimeout(resolve, 5000));
@@ -815,6 +821,35 @@ describe("Local-only Mode", () => {
       const result = await lbLocalJson<Array<{ priority: number }>>("create", "Urgent", "-p", "0");
 
       expect(result[0].priority).toBe(0);
+    });
+
+    test("should handle many concurrent creates without database lock errors", async () => {
+      const total = 30;
+      const jobs = Array.from({ length: total }, (_, idx) =>
+        Bun.spawn(["bun", "run", import.meta.dir + "/../src/cli.ts", "create", `Concurrent ${idx + 1}`], {
+          cwd: testDir,
+          stdout: "pipe",
+          stderr: "pipe",
+        })
+      );
+
+      const results = await Promise.all(
+        jobs.map(async (proc) => {
+          const stdout = await new Response(proc.stdout).text();
+          const stderr = await new Response(proc.stderr).text();
+          const exitCode = await proc.exited;
+          return { stdout, stderr, exitCode };
+        })
+      );
+
+      for (const result of results) {
+        expect(result.exitCode).toBe(0);
+        expect(result.stderr.toLowerCase()).not.toContain("database is locked");
+      }
+
+      const listed = await lbLocalJson<Array<{ title: string }>>("list", "--all");
+      const createdCount = listed.filter((issue) => issue.title.startsWith("Concurrent ")).length;
+      expect(createdCount).toBe(total);
     });
   });
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -18,6 +18,7 @@ import {
   afterEach,
   setDefaultTimeout,
 } from "bun:test";
+import { Database } from "bun:sqlite";
 import { GraphQLClient } from "graphql-request";
 import { mkdirSync, rmSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
@@ -737,6 +738,7 @@ describe("Local-only Mode", () => {
   ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
     const proc = Bun.spawn(["bun", "run", import.meta.dir + "/../src/cli.ts", ...args], {
       cwd: testDir,
+      env: { ...process.env, LB_TEAM_KEY: "" },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -755,6 +757,37 @@ describe("Local-only Mode", () => {
       throw new Error(`lb ${args.join(" ")} failed: ${result.stderr}\n${result.stdout}`);
     }
     return JSON.parse(result.stdout);
+  }
+
+  function seedCachedIssue(id: string, title: string): void {
+    const db = new Database(join(testDir, ".lb", "cache.db"));
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS issues (
+        id TEXT PRIMARY KEY,
+        identifier TEXT NOT NULL,
+        title TEXT NOT NULL,
+        description TEXT,
+        status TEXT NOT NULL,
+        priority INTEGER NOT NULL,
+        issue_type TEXT,
+        sync_status TEXT NOT NULL DEFAULT 'synced',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        closed_at TEXT,
+        assignee TEXT,
+        linear_state_id TEXT,
+        cached_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+
+    const now = new Date().toISOString();
+    db.run(
+      `INSERT OR REPLACE INTO issues
+      (id, identifier, title, status, priority, sync_status, created_at, updated_at)
+      VALUES (?, ?, ?, 'open', 2, 'synced', ?, ?)`,
+      [id, id, title, now, now]
+    );
+    db.close();
   }
 
   beforeAll(() => {
@@ -912,6 +945,31 @@ describe("Local-only Mode", () => {
       );
 
       expect(result[0].children).toContain(child[0].id);
+    });
+
+    test("should resolve compact IDs without dash", async () => {
+      seedCachedIssue("LIN-4321", "Compact ID test");
+      const result = await lbLocalJson<Array<{ id: string; title: string }>>("show", "LIN4321");
+      expect(result[0].id).toBe("LIN-4321");
+      expect(result[0].title).toBe("Compact ID test");
+    });
+
+    test("should resolve numeric IDs when prefix is unambiguous", async () => {
+      seedCachedIssue("LIN-9876", "Numeric inference test");
+      const result = await lbLocalJson<Array<{ id: string; title: string }>>("show", "9876");
+      expect(result[0].id).toBe("LIN-9876");
+      expect(result[0].title).toBe("Numeric inference test");
+    });
+
+    test("should hard-fail with choices when numeric ID is ambiguous", async () => {
+      seedCachedIssue("AAA-7777", "Ambiguous A");
+      seedCachedIssue("BBB-7777", "Ambiguous B");
+
+      const result = await lbLocal("show", "7777");
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Issue reference '7777' is ambiguous");
+      expect(result.stderr).toContain("AAA-7777");
+      expect(result.stderr).toContain("BBB-7777");
     });
   });
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1192,5 +1192,25 @@ describe("Local-only Mode", () => {
         [itemId]
       );
     });
+
+    test("should defer failed outbox items until next attempt window", async () => {
+      const script = `
+        import {
+          queueOutboxItem,
+          updateOutboxItemError,
+          getPendingOutboxItems,
+          removeOutboxItem,
+        } from '${import.meta.dir}/../src/utils/database.ts';
+        const id = queueOutboxItem('update', { issueId: 'LIN-TEST-BACKOFF', title: 'backoff' });
+        updateOutboxItemError(id, 'Rate limit exceeded retry-after":"3600"');
+        const pendingIds = getPendingOutboxItems().map((item) => item.id);
+        console.log(pendingIds.includes(id) ? 'pending' : 'deferred');
+        removeOutboxItem(id);
+      `;
+
+      const result = await evalLocal(script);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe("deferred");
+    });
   });
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -750,6 +750,24 @@ describe("Local-only Mode", () => {
     return { stdout, stderr, exitCode };
   }
 
+  async function evalLocal(
+    script: string,
+    args: string[] = []
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    const proc = Bun.spawn(["bun", "--eval", script, ...args], {
+      cwd: testDir,
+      env: { ...process.env, LB_TEAM_KEY: "" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    return { stdout, stderr, exitCode };
+  }
+
   // Helper to run lb and parse JSON output
   async function lbLocalJson<T>(...args: string[]): Promise<T> {
     const result = await lbLocal(...args, "--json");
@@ -1118,6 +1136,61 @@ describe("Local-only Mode", () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain(parent[0].id);
+    });
+  });
+
+  describe("outbox locking", () => {
+    test("should allow only one claimant per outbox item", async () => {
+      const queueScript = `
+        import { queueOutboxItem } from '${import.meta.dir}/../src/utils/database.ts';
+        console.log(queueOutboxItem('update', { issueId: 'LIN-TEST-LOCK', title: 'lock' }));
+      `;
+      const queued = await evalLocal(queueScript);
+      expect(queued.exitCode).toBe(0);
+      const itemId = queued.stdout.trim();
+      expect(itemId).toMatch(/^\\d+$/);
+
+      const claimScript = `
+        import { claimOutboxItem } from '${import.meta.dir}/../src/utils/database.ts';
+        const id = Number(process.argv[1]);
+        console.log(claimOutboxItem(id) ? 'claimed' : 'skipped');
+      `;
+
+      const procA = Bun.spawn(["bun", "--eval", claimScript, itemId], {
+        cwd: testDir,
+        env: { ...process.env, LB_TEAM_KEY: "" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const procB = Bun.spawn(["bun", "--eval", claimScript, itemId], {
+        cwd: testDir,
+        env: { ...process.env, LB_TEAM_KEY: "" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [outA, outB, codeA, codeB] = await Promise.all([
+        new Response(procA.stdout).text(),
+        new Response(procB.stdout).text(),
+        procA.exited,
+        procB.exited,
+      ]);
+
+      expect(codeA).toBe(0);
+      expect(codeB).toBe(0);
+
+      const results = [outA.trim(), outB.trim()].sort();
+      expect(results).toEqual(["claimed", "skipped"]);
+
+      await evalLocal(
+        `
+        import { removeOutboxItem, releaseOutboxItemClaim } from '${import.meta.dir}/../src/utils/database.ts';
+        const id = Number(process.argv[1]);
+        releaseOutboxItemClaim(id);
+        removeOutboxItem(id);
+      `,
+        [itemId]
+      );
     });
   });
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1151,7 +1151,7 @@ describe("Local-only Mode", () => {
       const queued = await evalLocal(queueScript);
       expect(queued.exitCode).toBe(0);
       const itemId = queued.stdout.trim();
-      expect(itemId).toMatch(/^\\d+$/);
+      expect(itemId).toMatch(/^\d+$/);
 
       const claimScript = `
         import { claimOutboxItem } from '${import.meta.dir}/../src/utils/database.ts';

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -877,11 +877,14 @@ describe("Local-only Mode", () => {
     test("should handle many concurrent creates without database lock errors", async () => {
       const total = 30;
       const jobs = Array.from({ length: total }, (_, idx) =>
-        Bun.spawn(["bun", "run", import.meta.dir + "/../src/cli.ts", "create", `Concurrent ${idx + 1}`], {
-          cwd: testDir,
-          stdout: "pipe",
-          stderr: "pipe",
-        })
+        Bun.spawn(
+          ["bun", "run", import.meta.dir + "/../src/cli.ts", "create", `Concurrent ${idx + 1}`],
+          {
+            cwd: testDir,
+            stdout: "pipe",
+            stderr: "pipe",
+          }
+        )
       );
 
       const results = await Promise.all(


### PR DESCRIPTION
Harden SQLite concurrency and outbox reliability

- Queue concurrent writes with exponential backoff retry instead of failing fast on SQLITE_BUSY
- Atomic LOCAL ID allocation to prevent duplicates under parallel writes
- Per-item outbox claims (60s timeout) to prevent duplicate processing
- Retry backoff scheduling for failed outbox items (rate limit aware, 1s-5min exponential)
- Sync waits for in-flight outbox claims to settle before completing
- Normalize shorthand issue IDs (LIN123 → LIN-123, 123 → inferred prefix) across all commands
